### PR TITLE
Release the chunkBuffer if an exception is thrown whilst reading

### DIFF
--- a/common/src/main/java/com/zegelin/prometheus/exposition/JsonFormatChunkedInput.java
+++ b/common/src/main/java/com/zegelin/prometheus/exposition/JsonFormatChunkedInput.java
@@ -466,7 +466,12 @@ public class JsonFormatChunkedInput implements ChunkedInput<ByteBuf> {
 
         // add slices till we hit the chunk size (or slightly over it), or hit EOF
         while (chunkBuffer.readableBytes() < 1024 * 1024 && state != State.EOF) {
-            nextSlice(chunkBuffer);
+            try {
+                nextSlice(chunkBuffer);
+            } catch (Exception e) {
+                chunkBuffer.release();
+                throw e;
+            }
         }
 
         return chunkBuffer;

--- a/common/src/main/java/com/zegelin/prometheus/exposition/TextFormatChunkedInput.java
+++ b/common/src/main/java/com/zegelin/prometheus/exposition/TextFormatChunkedInput.java
@@ -359,8 +359,8 @@ public class TextFormatChunkedInput implements ChunkedInput<ByteBuf> {
         while (chunkBuffer.readableBytes() < 1024 * 1024 && state != State.EOF) {
             try {
                 nextSlice(chunkBuffer);
-
             } catch (Exception e) {
+                chunkBuffer.release();
                 throw e;
             }
         }


### PR DESCRIPTION
If an exception was thrown due to an issue whilst reading the MetricFamily into the slice, the buffer wasn't released. Netty complains about ByteBuf being gc'ed without being explicitly released.