### PR TITLE
Convert timers from nanos to seconds

### DIFF
--- a/common/src/main/java/com/zegelin/cassandra/exporter/FactoriesSupplier.java
+++ b/common/src/main/java/com/zegelin/cassandra/exporter/FactoriesSupplier.java
@@ -407,7 +407,7 @@ public class FactoriesSupplier implements Supplier<List<Factory>> {
         return (name, help, labels, mBean) -> {
             final NamedObject<SamplingCounting> samplingCountingNamedObject = CassandraMetricsUtilities.jmxTimerMBeanAsSamplingCounting(mBean);
 
-            return new FunctionalMetricFamilyCollector<>(name, help, ImmutableMap.of(labels, samplingCountingNamedObject), samplingAndCountingAsSummary(MetricValueConversionFunctions::microsecondsToSeconds));
+            return new FunctionalMetricFamilyCollector<>(name, help, ImmutableMap.of(labels, samplingCountingNamedObject), samplingAndCountingAsSummary(MetricValueConversionFunctions::nanosecondsToSeconds));
         };
     }
 


### PR DESCRIPTION
Timer quantiles are converted from nanos to seconds when building summaries.

Closes #49