### PR TITLE
chore(netty): test with old netty lib

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.0.53.Final</version>
+            <version>4.0.34.Final</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Hi, I'd just like to test if exporter works with old netty lib. Do not merge :)