### PR TITLE
Don't depend on sun.security package

### DIFF
--- a/common/src/test/java/com/zegelin/cassandra/exporter/netty/ssl/TestSslContextFactory.java
+++ b/common/src/test/java/com/zegelin/cassandra/exporter/netty/ssl/TestSslContextFactory.java
@@ -7,7 +7,7 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import sun.security.ssl.SSLEngineImpl;
+import javax.net.ssl.SSLEngine;
 
 import java.io.File;
 import java.io.IOException;
@@ -46,7 +46,7 @@ public class TestSslContextFactory {
 
         SslContext context = contextFactory.createSslContext();
 
-        assertThat(context.newEngine(ByteBufAllocator.DEFAULT)).isInstanceOf(SSLEngineImpl.class);
+        assertThat(context.newEngine(ByteBufAllocator.DEFAULT)).isInstanceOf(SSLEngine.class);
     }
 
     @Test
@@ -163,7 +163,7 @@ public class TestSslContextFactory {
 
         SslContext context = contextFactory.createSslContext();
 
-        assertThat(context.newEngine(ByteBufAllocator.DEFAULT)).isInstanceOf(SSLEngineImpl.class);
+        assertThat(context.newEngine(ByteBufAllocator.DEFAULT)).isInstanceOf(SSLEngine.class);
     }
 
     @Test
@@ -175,7 +175,7 @@ public class TestSslContextFactory {
 
         SslContext context = contextFactory.createSslContext();
 
-        assertThat(context.newEngine(ByteBufAllocator.DEFAULT)).isInstanceOf(SSLEngineImpl.class);
+        assertThat(context.newEngine(ByteBufAllocator.DEFAULT)).isInstanceOf(SSLEngine.class);
     }
 
     @Test


### PR DESCRIPTION
This is not portable, and fails depending on the JVM used, see https://www.oracle.com/java/technologies/faq-sun-packages.html:

> The sun.* packages are not part of the supported, public interface.
> A Java program that directly calls into sun.* packages is not
> guaranteed to work on all Java-compatible platforms. In fact, such a
> program is not guaranteed to work even in future versions on the same
> platform.

Also:

    $ docker run --rm -ti -v $PWD:/src -w /src maven:3-openjdk-11 mvn package
    [...]
    [ERROR] COMPILATION ERROR :
    [INFO] -------------------------------------------------------------
    [ERROR] /src/common/src/test/java/com/zegelin/cassandra/exporter/netty/ssl/TestSslContextFactory.java:[10,24] sun.security.ssl.SSLEngineImpl is not public in sun.security.ssl; cannot be accessed from outside package
    [ERROR] /src/common/src/test/java/com/zegelin/cassandra/exporter/netty/ssl/TestSslContextFactory.java:[49,78] sun.security.ssl.SSLEngineImpl is not public in sun.security.ssl; cannot be accessed from outside package
    [ERROR] /src/common/src/test/java/com/zegelin/cassandra/exporter/netty/ssl/TestSslContextFactory.java:[166,78] sun.security.ssl.SSLEngineImpl is not public in sun.security.ssl; cannot be accessed from outside package
    [ERROR] /src/common/src/test/java/com/zegelin/cassandra/exporter/netty/ssl/TestSslContextFactory.java:[178,78] sun.security.ssl.SSLEngineImpl is not public in sun.security.ssl; cannot be accessed from outside package
    [...]

For some reason, the tests pass with the CircleCI Java Docker image; I tried with various combination of the JDK (dockerized Maven's `maven:3-openjdk-11` and `maven:3-openjdk-8` and the JDK from Oracle's own website) and none work.