### PR TITLE
Exclude keyspaces matching regex patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The available command line options may be seen by passing `-h`/`--help`:
                                 Record the cumulative time taken to run each collector
                                   and export the results.
           --exclude-keyspaces=<excludedKeyspaces>
-    
+                                Exclude keyspaces matching the specified regex pattern.
       -e, --exclude=EXCLUSION...
                                 Exclude a metric family or MBean from exposition.
                                   EXCLUSION may be the full name of a metric family

--- a/common/src/main/java/com/zegelin/cassandra/exporter/FactoriesSupplier.java
+++ b/common/src/main/java/com/zegelin/cassandra/exporter/FactoriesSupplier.java
@@ -370,7 +370,7 @@ public class FactoriesSupplier implements Supplier<List<Factory>> {
 
                                 final String keyspaceName = keyPropertyList.get("keyspace");
 
-                                if (excludedKeyspaces.contains(keyspaceName)) {
+                                if (excludedKeyspaces.stream().anyMatch(p -> keyspaceName.matches(p))) {
                                     return false;
                                 }
 

--- a/common/src/main/java/com/zegelin/cassandra/exporter/cli/HarvesterOptions.java
+++ b/common/src/main/java/com/zegelin/cassandra/exporter/cli/HarvesterOptions.java
@@ -140,7 +140,8 @@ public class HarvesterOptions {
     public boolean collectorTimingEnabled;
 
 
-    @Option(names = "--exclude-keyspaces")
+    @Option(names = "--exclude-keyspaces",
+            description = "Exclude keyspaces matching the specified regex pattern.")
     public Set<String> excludedKeyspaces = new HashSet<>();
 
     @Option(names = "--exclude-system-tables",

--- a/common/src/main/java/com/zegelin/cassandra/exporter/collector/StorageServiceMBeanMetricFamilyCollector.java
+++ b/common/src/main/java/com/zegelin/cassandra/exporter/collector/StorageServiceMBeanMetricFamilyCollector.java
@@ -93,7 +93,7 @@ public class StorageServiceMBeanMetricFamilyCollector extends MBeanGroupMetricFa
 
         {
             final Stream<NumericMetric> ownershipMetricStream = metadataFactory.keyspaces().stream()
-                    .filter(keyspace -> !excludedKeyspaces.contains(keyspace))
+                    .filter(keyspace -> !excludedKeyspaces.stream().anyMatch(p -> keyspace.matches(p)))
                     .flatMap(keyspace -> {
                         try {
                             return storageServiceMBean.effectiveOwnership(keyspace).entrySet().stream()

--- a/install-ccm.sh
+++ b/install-ccm.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+HERE="$(dirname "$(readlink -f "$0")")"
+
+AGENT="$HERE/agent/target/cassandra-exporter-agent-0.9.11-SNAPSHOT.jar"
+
 find . -path '*/node*/conf/cassandra-env.sh' | while read file; do
     echo "Processing $file"
 
@@ -7,6 +11,8 @@ find . -path '*/node*/conf/cassandra-env.sh' | while read file; do
 
     sed -i -e "/cassandra-exporter/d" "${file}"
 
-    echo "JVM_OPTS=\"\$JVM_OPTS -javaagent:/home/adam/Projects/cassandra-exporter/agent/target/cassandra-exporter-agent-0.9.4-SNAPSHOT.jar=--listen=:${port},--cache=true,--enable-collector-timing\"" >> \
-        "${file}"
+    cat <<EOF >> "${file}"
+JVM_OPTS="\$JVM_OPTS -javaagent:$AGENT=--listen=:${port},--enable-collector-timing"
+EOF
+
 done;


### PR DESCRIPTION
Instead of matching a specific keyspace name, --exclude-keyspaces now
takes a regex as an argument; every keyspaces which match the regex will
be ignored.

This is not entirely backward compatible, as
`--exclude-keyspaces=foobar` will exclude `foobar`, but also
`some_foobar_keyspace` as well.