### PR TITLE
Support for 4.0

### DIFF
--- a/agent/src/main/java/com/zegelin/cassandra/exporter/InternalMetadataFactory.java
+++ b/agent/src/main/java/com/zegelin/cassandra/exporter/InternalMetadataFactory.java
@@ -88,6 +88,6 @@ public class InternalMetadataFactory extends MetadataFactory {
 
     @Override
     public InetAddress localBroadcastAddress() {
-        return FBUtilities.getBroadcastAddressAndPort().getAddress();
+        return FBUtilities.getBroadcastAddressAndPort().address;
     }
 }

--- a/agent/src/main/java/com/zegelin/cassandra/exporter/collector/InternalGossiperMBeanMetricFamilyCollector.java
+++ b/agent/src/main/java/com/zegelin/cassandra/exporter/collector/InternalGossiperMBeanMetricFamilyCollector.java
@@ -37,10 +37,9 @@ public class InternalGossiperMBeanMetricFamilyCollector extends GossiperMBeanMet
     @Override
     protected void collect(final Stream.Builder<NumericMetric> generationNumberMetrics, final Stream.Builder<NumericMetric> downtimeMetrics, final Stream.Builder<NumericMetric> activeMetrics) {
         for (InetAddressAndPort endpoint : gossiper.getEndpoints()) {
-            final InetAddress endpointAddress = endpoint.getAddress();
             final EndpointState state = gossiper.getEndpointStateForEndpoint(endpoint);
 
-            final Labels labels = metadataFactory.endpointLabels(endpointAddress);
+            final Labels labels = metadataFactory.endpointLabels(endpoint.address);
 
             generationNumberMetrics.add(new NumericMetric(labels, gossiper.getCurrentGenerationNumber(endpoint)));
             downtimeMetrics.add(new NumericMetric(labels, millisecondsToSeconds(gossiper.getEndpointDowntime(endpoint))));

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     </modules>
 
     <properties>
-        <version.cassandra.all>4.1.0</version.cassandra.all>
+        <version.cassandra.all>4.0.11</version.cassandra.all>
 
         <version.maven.release.plugin>2.5.3</version.maven.release.plugin>
         <version.maven.dependency.plugin>3.1.1</version.maven.dependency.plugin>


### PR DESCRIPTION
The README states that it is working with 4.x but if run with 4.0, all you get is a stacktrace and no metrics. This patch makes it possible to run with 4.0.