### PR TITLE
Cassandra 2 support

### DIFF
--- a/common/src/main/java/com/zegelin/jmx/NamedObject.java
+++ b/common/src/main/java/com/zegelin/jmx/NamedObject.java
@@ -1,6 +1,6 @@
 package com.zegelin.jmx;
 
-import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
 import javax.management.ObjectName;
@@ -36,7 +36,7 @@ public class NamedObject<T> {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
+        return Objects.toStringHelper(this)
                 .add("name", name)
                 .add("object", object)
                 .toString();

--- a/common/src/main/java/com/zegelin/prometheus/domain/MetricFamily.java
+++ b/common/src/main/java/com/zegelin/prometheus/domain/MetricFamily.java
@@ -1,7 +1,5 @@
 package com.zegelin.prometheus.domain;
 
-import com.google.common.base.MoreObjects;
-
 import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -41,7 +39,7 @@ public abstract class MetricFamily<T extends Metric> {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
+        return com.google.common.base.Objects.toStringHelper(this)
                 .add("name", name)
                 .add("help", help)
                 .toString();

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     </modules>
 
     <properties>
-        <version.cassandra.all>3.11.2</version.cassandra.all>
+        <version.cassandra.all>2.2.18</version.cassandra.all>
 
         <version.maven.release.plugin>2.5.3</version.maven.release.plugin>
         <version.maven.dependency.plugin>3.1.1</version.maven.dependency.plugin>


### PR DESCRIPTION
WIP of Cassandra 2.2.x support (specifically, 2.2.18). The branch is based off of tag v0.9.10 (the compatibility chart here https://github.com/instaclustr/cassandra-exporter?tab=readme-ov-file#compatibility says v0.9.11 is the version that supports Cassandra 3 but I couldn't find any corresponding git tag)

Closes https://github.com/instaclustr/cassandra-exporter/issues/18